### PR TITLE
docs: add .env.example documenting required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# StateCraft — environment variables
+# StateCraft creates/deletes Terraform state backends (S3 bucket + DynamoDB
+# lock table) via boto3. AWS credentials come from the standard boto3 chain
+# (the variables below, shared config/profile, or an attached IAM role), and
+# may also be supplied per-request. Copy to `.env` and fill in.
+# Do NOT commit your real `.env`.
+
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=eu-west-1
+# AWS_SESSION_TOKEN=   # only for temporary (STS) credentials


### PR DESCRIPTION
Adds a documented `.env.example` listing the environment variables this service reads, with placeholder values and comments — improves onboarding and ops clarity (no `.env.example` existed before).

Part of `000_INT_DOG_OpenPrime-153`. (Injecto needs none — fully request/CLI-driven.)