### PR TITLE
chore: remove unused field_validator import

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -11,7 +11,7 @@ from enum import Enum
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from core import (
     create_dynamodb_table,


### PR DESCRIPTION
Removes the unused `field_validator` import from `src/api.py` (imported but never referenced). The remaining pydantic imports `BaseModel` and `Field` are kept as they are actively used.

Verified with `python -m compileall src/`.