### PR TITLE
Add PodDisruptionBudget + bump chart to 0.4.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: ^chart/
       - id: check-json
       - id: check-added-large-files
       - id: check-executables-have-shebangs

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,10 +4,10 @@ description: AWS Terraform State Backend Infrastructure Manager - FastAPI micros
 type: application
 
 # Chart version - follows SemVer
-version: 0.4.0
+version: 0.4.1
 
 # Application version - matches StateCraft release version
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 
 # Project links
 home: https://github.com/devopsgroupeu/statecraft

--- a/chart/templates/poddisruptionbudget.yaml
+++ b/chart/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "statecraft.fullname" . }}
+  labels:
+    {{- include "statecraft.labels" . | nindent 4 }}
+spec:
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "statecraft.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,14 @@
 # Replica configuration
 replicaCount: 1
 
+# Pod Disruption Budget - disabled by default because this chart defaults to a
+# single replica (a PDB would block node drains). Enable with minAvailable: 1
+# where the service runs >=2 replicas (as it does in production), or
+# maxUnavailable: 0 to deliberately protect a single stateful replica.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
 # Container image configuration
 image:
   repository: ghcr.io/devopsgroupeu/statecraft


### PR DESCRIPTION
Adds a gated PodDisruptionBudget template (disabled by default — chart defaults to a single replica; enabled via GitOps where the service runs 2 replicas). Bumps chart version to 0.4.1 / appVersion to 0.3.1. Also excludes `chart/` from the check-yaml pre-commit hook (Helm templates are not standalone YAML), matching the openprime-app convention.

Merging publishes chart `statecraft-0.4.1` (helm-release on chart/** push). The pinned image `0.3.1` is minted separately by cutting the `0.3.1` GitHub release.