### PR TITLE
feat: require service token on mutating API endpoints

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0

--- a/src/api.py
+++ b/src/api.py
@@ -10,9 +10,10 @@ import logging
 from enum import Enum
 from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from auth import require_service_token
 from core import (
     create_dynamodb_table,
     create_s3_bucket,
@@ -95,7 +96,12 @@ async def health_check():
     }
 
 
-@app.post("/resources/create", response_model=ResourceResponse, tags=["Resources"])
+@app.post(
+    "/resources/create",
+    response_model=ResourceResponse,
+    tags=["Resources"],
+    dependencies=[Depends(require_service_token)],
+)
 async def create_resources(request: ResourceRequest):
     """Create S3 bucket and optionally DynamoDB table for Terraform backend.
 
@@ -160,7 +166,12 @@ async def create_resources(request: ResourceRequest):
     )
 
 
-@app.post("/resources/delete", response_model=ResourceResponse, tags=["Resources"])
+@app.post(
+    "/resources/delete",
+    response_model=ResourceResponse,
+    tags=["Resources"],
+    dependencies=[Depends(require_service_token)],
+)
 async def delete_resources(request: ResourceRequest):
     """Delete S3 bucket and optionally DynamoDB table.
 

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,44 @@
+"""Service-to-service authentication for the StateCraft API.
+
+StateCraft creates and irreversibly deletes Terraform state buckets, so it must
+only be callable by the OpenPrime backend. A shared service token (sent as the
+``X-Service-Token`` header) is validated on every mutating endpoint.
+
+Auth is only enforced when ``SERVICE_TOKEN`` is configured; when it is unset the
+dependency is a no-op (backward-compatible until the secret is wired into the
+backend and this service), which is logged loudly at startup. NetworkPolicy
+remains a second, independent layer.
+"""
+
+import logging
+import os
+import secrets
+from typing import Optional
+
+from fastapi import Header, HTTPException
+
+logger = logging.getLogger(__name__)
+
+SERVICE_TOKEN = os.getenv("SERVICE_TOKEN")
+
+if not SERVICE_TOKEN:
+    logger.warning(
+        "SERVICE_TOKEN not set — StateCraft request authentication is DISABLED (dev only)"
+    )
+
+
+def token_is_authorized(provided: Optional[str], expected: Optional[str]) -> bool:
+    """Return True if the request is authorized.
+
+    Authorization passes when no token is configured (auth disabled) or when the
+    provided token matches the expected one in constant time.
+    """
+    if not expected:
+        return True
+    return bool(provided) and secrets.compare_digest(provided, expected)
+
+
+async def require_service_token(x_service_token: Optional[str] = Header(default=None)):
+    """FastAPI dependency that rejects requests lacking a valid service token."""
+    if not token_is_authorized(x_service_token, SERVICE_TOKEN):
+        raise HTTPException(status_code=401, detail="Invalid or missing service token")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the application modules under src/ importable from tests.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,23 @@
+"""Tests for the service-token authorization helper."""
+
+from auth import token_is_authorized
+
+
+def test_disabled_when_no_expected_token():
+    # With no configured token, auth is disabled and accepts anything.
+    assert token_is_authorized(None, None) is True
+    assert token_is_authorized("anything", None) is True
+    assert token_is_authorized(None, "") is True
+
+
+def test_accepts_matching_token():
+    assert token_is_authorized("s3cr3t-token", "s3cr3t-token") is True
+
+
+def test_rejects_wrong_token():
+    assert token_is_authorized("wrong", "s3cr3t-token") is False
+
+
+def test_rejects_missing_token_when_required():
+    assert token_is_authorized(None, "s3cr3t-token") is False
+    assert token_is_authorized("", "s3cr3t-token") is False


### PR DESCRIPTION
StateCraft creates and **irreversibly deletes** Terraform state buckets, so it must only be callable by the OpenPrime backend (audit top risk #1 — unauthenticated /resources/delete).

## What
- Validates a shared `X-Service-Token` header on `/resources/create` and `/resources/delete` via a FastAPI dependency (constant-time compare). `/` and `/health` stay public for probes.
- **Staged rollout:** auth enforced only when `SERVICE_TOKEN` is set; unset = no-op + startup warning. Ships safely, then the shared secret is wired in to activate.
- Adds lightweight pytest coverage for the token-authorization helper.

## Activation (follow-up, ops)
Shared `SERVICE_TOKEN` secret → inject into injecto/statecraft/backend via GitOps/External Secrets. Delete-endpoint ownership/soft-delete hardening is a separate follow-up.

Note: Python CI is currently disabled here, so tests run locally (`pip install -r requirements-dev.txt && pytest`).