### PR TITLE
feat(chart): add extraEnv/envFrom passthrough

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,7 +4,7 @@ description: AWS Terraform State Backend Infrastructure Manager - FastAPI micros
 type: application
 
 # Chart version - follows SemVer
-version: 0.4.1
+version: 0.4.2
 
 # Application version - matches StateCraft release version
 appVersion: "0.3.1"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -75,6 +75,13 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -153,6 +153,18 @@ app:
     LOG_LEVEL: "INFO"
     # Additional environment variables can be added here
 
+# Additional environment variables in list form (supports valueFrom, e.g. a
+# secretKeyRef for the service auth token). Merged with app.env.
+extraEnv: []
+  # - name: SERVICE_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: openprime-service-token
+  #       key: SERVICE_TOKEN
+
+# Additional envFrom sources (e.g. a secretRef pulling all keys from a Secret).
+envFrom: []
+
 # Health check configuration
 healthCheck:
   enabled: true


### PR DESCRIPTION
Adds `extraEnv` (list, supports `valueFrom`) and `envFrom` passthrough to the deployment, matching the injecto chart. This is needed so the shared service auth token (`SERVICE_TOKEN`) can be injected from a Kubernetes Secret via `secretKeyRef` — the StateCraft chart previously only supported plain `app.env` and the AWS-credentials secret.

Bumps chart to `0.4.2`. No application code change. Enables the prod activation of the Injecto/StateCraft service auth (StateCraft PR #9).